### PR TITLE
Add MAINTAINERS.md — designate repository maintainer (for Copilot application)

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,58 @@
+```markdown
+
+MAINTAINERS
+
+
+
+\- 名称: 谢涛 (Xie Tao)
+
+\- GitHub: DigitalPlatform
+
+\- 邮箱: xietao@dp2003.com
+
+\- 角色: 仓库所有者 / 主要维护者
+
+
+
+该文件用于指定仓库的官方维护者，可作为申请 GitHub Copilot verified open-source maintainer 资格时的证明材料。
+
+关联 issue: https://github.com/DigitalPlatform/dp2/issues/1209
+
+
+
+说明:
+
+\- 若需更新维护者信息，请提交修改 MAINTAINERS.md 的 PR。
+
+
+
+---
+
+
+
+MAINTAINERS (English)
+
+
+
+\- Name: Xie Tao
+
+\- GitHub: DigitalPlatform
+
+\- Email: xietao@dp2003.com
+
+\- Role: Repository owner / primary maintainer
+
+
+
+This file designates the official maintainer(s) of the repository and may be used as proof of maintainer status for requests such as GitHub Copilot for verified open-source maintainers.
+
+Related issue: https://github.com/DigitalPlatform/dp2/issues/1209
+
+
+
+Instructions:
+
+\- To update this file, submit a PR modifying MAINTAINERS.md.
+
+```
+


### PR DESCRIPTION
中文：
我添加了 MAINTAINERS.md，声明谢涛（GitHub: DigitalPlatform，邮箱 [xietao@dp2003.com](mailto:xietao@dp2003.com)）为仓库所有者与主要维护者。该文件可作为向 GitHub 申请 Copilot 开源维护者资质的证明。关联 issue: #1209
English:
This PR adds MAINTAINERS.md designating Xie Tao (GitHub: DigitalPlatform, email: [xietao@dp2003.com](mailto:xietao@dp2003.com)) as the repository owner / primary maintainer. The file can be used as proof of maintainer status for GitHub Copilot verified open-source maintainer requests. Related issue: #1209